### PR TITLE
Fix 2012 path

### DIFF
--- a/tps/common.bash
+++ b/tps/common.bash
@@ -7,7 +7,7 @@ SYS_ENV_REG="HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
 RPMS_DIR=$INPUT_FOLDER
 
 if [[ $OTOOL_OS_VERSION -eq 2012 ]]; then
-  JAVA_INSTALL_DIR="C:\Users\$CURRENT_USER_NAME\java"
+  JAVA_INSTALL_DIR="C:\\Users\\$CURRENT_USER_NAME\java"
   JAVA_INSTALL_DIR_REG="C:\\\\Users\\\\$CURRENT_USER_NAME\\\\java"  
 fi
 

--- a/tps/testlib.bash
+++ b/tps/testlib.bash
@@ -25,8 +25,8 @@ source "$TPS_SCRIPT_DIR/common.bash"
 if [[ $OTOOL_OS_VERSION -eq 2012 ]]; then
   mkdir -p /cygdrive/c/Users/$CURRENT_USER_NAME/java
   mkdir -p /cygdrive/c/Users/$CURRENT_USER_NAME/tps
-  JAVA_INSTALL_DIR="C:\Users\$CURRENT_USER_NAME\java"
-  LOG_DIR_WIN="C:\Users\$CURRENT_USER_NAME\tps"
+  JAVA_INSTALL_DIR="C:\Users\\$CURRENT_USER_NAME\java"
+  LOG_DIR_WIN="C:\Users\\$CURRENT_USER_NAME\tps"
 fi
 
 parseArguments() {


### PR DESCRIPTION
This fixes failures due to incorrect path on Windows Server 2012.

The fix has been tested locally and it's passing.